### PR TITLE
feat(arch): implement offline-first architecture & harden security

### DIFF
--- a/app/(authed)/dashboard/sessions/page.tsx
+++ b/app/(authed)/dashboard/sessions/page.tsx
@@ -61,7 +61,7 @@ const SessionsContent = memo(
       onRequestDelete: (s: Session) => void;
     }) {
     const { sessions } = useDashboard();
-    const sessionList = useMemo(()=>{
+    const sessionList = useMemo(() => {
       return sessions ?? [];
     }, [sessions]);
 
@@ -275,7 +275,10 @@ export default function SessionLog() {
 
           <DialogFooter>
             <Button variant="outline" onClick={() => setEditingSession(null)}>Cancel</Button>
-            <Button onClick={handleSaveEdit} disabled={isUpdating}>Save changes</Button>
+            <Button
+              onClick={handleSaveEdit}
+            // disabled={isUpdating}
+            >Save changes</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/lib/schemas/sessionSchema.ts
+++ b/lib/schemas/sessionSchema.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+// Validation Rules
+export const SessionSchema = z.object({
+    // We DO NOT include 'id' here because Firestore generates it
+    // We DO NOT include 'userId' here if it's strictly in the path, 
+    // but if you store it in the doc, validate it.
+    userId: z.string().min(1, "User ID is required"),
+
+    title: z.string().min(0).max(150, "Title is too long"),
+    session_type_id: z.string(),
+    notes: z.string().optional().default(""),
+
+    // Timestamps must be valid ISO strings
+    started_at: z.iso.datetime({ message: "Invalid start date format" }),
+    ended_at: z.iso.datetime({ message: "Invalid end date format" }),
+
+    // Durations must be non-negative integers
+    total_focus_ms: z.number().int().nonnegative("Focus time cannot be negative"),
+    total_break_ms: z.number().int().nonnegative("Break time cannot be negative"),
+
+    // Strict structure for breaks
+    breaks: z.array(
+        z.object({
+            start: z.number().int(),
+            end: z.number().int(),
+            duration: z.number().int().nonnegative(),
+        })
+    ).default([]),
+
+});
+
+// Infer the type from the schema automatically
+export type CreateSessionInput = z.infer<typeof SessionSchema>;

--- a/lib/utils/error.ts
+++ b/lib/utils/error.ts
@@ -13,7 +13,7 @@ export function formatError(err: unknown, fallback = 'An unexpected error occurr
         return err;
     }
 
-    // Optional: handle Firebase/Auth errors if you use them
+    // handle Firebase/Auth errors
     if (typeof err === 'object' && err !== null && 'code' in err) {
         const code = (err as { code?: string }).code;
         return `Error code: ${code ?? 'unknown'}`;


### PR DESCRIPTION
SECURITY:
- CSP: Implemented strict Nonce-based Content Security Policy in `middleware.ts`.
- Validation: Added Zod schemas to enforce strict data types on write.
- ID Gen: Removed insecure `nanoid`. Switched to `doc(collection).id` for secure, collision-resistant, offline-compatible IDs.

OFFLINE ARCHITECTURE:
- Writes: Refactored mutations to "Fire-and-Forget" pattern (no await) to prevent UI blocking.
- Reads: Switched from `getDocs` (Server-First) to `onSnapshot` (Sync-First) to preserve local pending writes.
- State: Updated React Query `queryFn` to "Cache-Only" to prevent server fetches from wiping local optimistic state.

INFRA:
- Migrated deployment to Vercel (`deepsession-mpt`).
- Configured Vercel Analytics & Speed Insights.

Fix #5